### PR TITLE
Fix Leaflet default marker icon globally

### DIFF
--- a/src/components/MapPicker.tsx
+++ b/src/components/MapPicker.tsx
@@ -7,14 +7,11 @@ import { motion, AnimatePresence } from 'motion/react';
 import { useAppContext } from '../context/AppContext';
 
 // Fix Leaflet default marker icon issue
-const markerIcon = new L.Icon({
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
   iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
   iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
   shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41]
 });
 
 function DraggableMarker({ position, onDragEnd }: { position: [number, number]; onDragEnd: (lat: number, lng: number) => void }) {
@@ -29,7 +26,6 @@ function DraggableMarker({ position, onDragEnd }: { position: [number, number]; 
   return (
     <Marker
       position={position}
-      icon={markerIcon}
       draggable
       ref={markerRef}
       eventHandlers={{


### PR DESCRIPTION
This change implements a global fix for Leaflet's default marker icons by overriding `L.Icon.Default` configuration in `MapPicker.tsx`. 

Bundlers like Vite often fail to resolve the relative asset paths within Leaflet's default CSS, leading to broken marker images. Instead of passing a custom icon to every `Marker` component, this implementation globally overrides the default icon settings using official assets from the unpkg CDN. 

Specifically:
- Deleted `L.Icon.Default.prototype._getIconUrl` to prevent incorrect auto-detection.
- Used `L.Icon.Default.mergeOptions` to set correct URLs for `iconUrl`, `iconRetinaUrl`, and `shadowUrl`.
- Cleaned up redundant local icon definitions and `icon` props.

---
*PR created automatically by Jules for task [3953216085491955997](https://jules.google.com/task/3953216085491955997) started by @DhaatuTheGamer*