### PR TITLE
🧹 fix: Remove unused OrderStatus import in CaptainDashboard.tsx

### DIFF
--- a/src/components/captain/CaptainDashboard.tsx
+++ b/src/components/captain/CaptainDashboard.tsx
@@ -4,7 +4,7 @@ import {
   Truck, MapPin, Fuel, Clock, CheckCircle2, XCircle, DollarSign,
   Star, ChevronRight, Shield, User, Phone, Navigation, Package, Zap, MessageSquareText, ExternalLink
 } from 'lucide-react';
-import { Order, OrderStatus } from '../../types';
+import { Order } from '../../types';
 import { getActiveOrders, onOrderChange, updateOrderStatus, removeOrder } from '../../services/orderBridge';
 
 const SAFETY_ITEMS = [


### PR DESCRIPTION
🎯 **What:** Removed unused `OrderStatus` import from `src/components/captain/CaptainDashboard.tsx`.
💡 **Why:** Static analysis shows the symbol is imported but not referenced anywhere else in the file. Removing unused imports improves code readability and maintainability.
✅ **Verification:** Verified by building the application successfully using `npm run build`. The code review also confirmed the change is correct.
✨ **Result:** Improved code health by removing dead code without changing functionality.

---
*PR created automatically by Jules for task [6492519371356996902](https://jules.google.com/task/6492519371356996902) started by @DhaatuTheGamer*