### PR TITLE
🧹 Remove unused Plus import in MapPicker

### DIFF
--- a/src/components/MapPicker.tsx
+++ b/src/components/MapPicker.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import { Location } from '../types';
-import { MapPin, Navigation, Loader2, Bookmark, Plus, X, Home, Briefcase, Dumbbell, Coffee } from 'lucide-react';
+import { MapPin, Navigation, Loader2, Bookmark, X, Home, Briefcase, Dumbbell, Coffee } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useAppContext } from '../context/AppContext';
 


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`Plus` icon from `lucide-react`) in `src/components/MapPicker.tsx`.
💡 **Why:** To address a code health issue, reducing unnecessary imports and making the file cleaner and more maintainable.
✅ **Verification:** Verified that `Plus` is indeed not referenced anywhere in the file. Code review confirmed this is a safe and correct cleanup.
✨ **Result:** Improved code cleanliness without any impact on functionality.

---
*PR created automatically by Jules for task [5272237745630595192](https://jules.google.com/task/5272237745630595192) started by @DhaatuTheGamer*