### PR TITLE
🧹 [code health] Remove unused MapPin import in BulkOrder

### DIFF
--- a/src/components/BulkOrder.tsx
+++ b/src/components/BulkOrder.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { ArrowLeft, Car, Fuel, Plus, Trash2, ArrowRight, Users, MapPin } from 'lucide-react';
+import { ArrowLeft, Car, Fuel, Plus, Trash2, ArrowRight, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../context/AppContext';
 import { FuelType, Vehicle } from '../types';


### PR DESCRIPTION
🎯 **What:** Removed the unused `MapPin` import from `lucide-react` in `src/components/BulkOrder.tsx`.
💡 **Why:** `MapPin` was imported but not referenced anywhere in the file. Removing unused imports improves code readability, reduces potential confusion, and clears up static analysis warnings.
✅ **Verification:** Verified that the removal did not introduce any regressions by running `npm run lint` (`tsc --noEmit`), which completed without errors. Code review also confirmed the change is correct and safe.
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [8787654358963214804](https://jules.google.com/task/8787654358963214804) started by @DhaatuTheGamer*