### PR TITLE
🧹 [code health] Remove unused ShoppingCart import in OrderFuel.tsx

### DIFF
--- a/src/components/OrderFuel.tsx
+++ b/src/components/OrderFuel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { ArrowLeft, Car, Fuel as FuelIcon, ArrowRight, Clock, TrendingDown, TrendingUp, ShoppingCart, Plus, Zap, MessageSquareText, CheckCircle2 } from 'lucide-react';
+import { ArrowLeft, Car, Fuel as FuelIcon, ArrowRight, Clock, TrendingDown, TrendingUp, Plus, Zap, MessageSquareText, CheckCircle2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../context/AppContext';
 import { FuelType } from '../types';


### PR DESCRIPTION
🎯 **What:** Removed the unused `ShoppingCart` import from `lucide-react` in `src/components/OrderFuel.tsx`.
💡 **Why:** The import was flagged by static analysis as completely unused. Removing dead code reduces clutter and improves readability.
✅ **Verification:** Ran `npm run lint` and `npm run build` to confirm the removal did not introduce any regressions or type errors.
✨ **Result:** A cleaner component file without unnecessary dependency imports.

---
*PR created automatically by Jules for task [6163858141818738903](https://jules.google.com/task/6163858141818738903) started by @DhaatuTheGamer*