### PR TITLE
🧹 [code health] Remove unused ChevronRight import from Home component

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'motion/react';
-import { MapPin, Bell, Fuel, Car, Clock, ChevronRight, Settings, ArrowRight, AlertCircle, Droplets, Users } from 'lucide-react';
+import { MapPin, Bell, Fuel, Car, Clock, Settings, ArrowRight, AlertCircle, Droplets, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../context/AppContext';
 import VehicleSelectModal from './VehicleSelectModal';


### PR DESCRIPTION
🎯 **What:** Removed the unused `ChevronRight` import from `lucide-react` in `src/components/Home.tsx`.
💡 **Why:** The `ChevronRight` icon was imported but never referenced in the component. Removing it reduces dead code, slightly improves bundle size theoretically, and enhances overall codebase readability and maintainability.
✅ **Verification:** Verified by running `npm run lint` (typecheck) and `npm run build` locally, ensuring no build errors or broken types. The change is safe as it simply removes unused dead code.
✨ **Result:** A cleaner component with no unused imports.

---
*PR created automatically by Jules for task [2275064660479489726](https://jules.google.com/task/2275064660479489726) started by @DhaatuTheGamer*