### PR TITLE
🧹 Refactor MapPicker to extract subcomponents

### DIFF
--- a/src/components/ManualAddressEntry.tsx
+++ b/src/components/ManualAddressEntry.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+interface ManualAddressEntryProps {
+  onSubmit: (address: string) => void;
+  onCancel: () => void;
+}
+
+export default function ManualAddressEntry({ onSubmit, onCancel }: ManualAddressEntryProps) {
+  const [manualAddress, setManualAddress] = useState('');
+
+  const handleManualSubmit = () => {
+    if (manualAddress.trim()) {
+      onSubmit(manualAddress);
+    }
+  };
+
+  return (
+    <div>
+      <textarea
+        value={manualAddress}
+        onChange={(e) => setManualAddress(e.target.value)}
+        placeholder="Enter complete delivery address..."
+        className="input-brutal resize-none h-20 mb-2"
+      />
+      <div className="flex space-x-2">
+        <button onClick={handleManualSubmit} className="btn-primary flex-1 py-2 text-sm">
+          Confirm Address
+        </button>
+        <button onClick={onCancel} className="btn-secondary flex-1 py-2 text-sm">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MapPicker.tsx
+++ b/src/components/MapPicker.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import { Location } from '../types';
-import { MapPin, Navigation, Loader2, Bookmark, Plus, X, Home, Briefcase, Dumbbell, Coffee } from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
+import { MapPin, Navigation, Loader2, Bookmark } from 'lucide-react';
 import { useAppContext } from '../context/AppContext';
+import SavedAddressChips from './SavedAddressChips';
+import SaveAddressDialog from './SaveAddressDialog';
+import ManualAddressEntry from './ManualAddressEntry';
 
 // Fix Leaflet default marker icon issue
 const markerIcon = new L.Icon({
@@ -45,13 +47,6 @@ function DraggableMarker({ position, onDragEnd }: { position: [number, number]; 
   );
 }
 
-const EMOJI_OPTIONS = [
-  { emoji: '🏠', label: 'Home', icon: <Home size={16} /> },
-  { emoji: '🏢', label: 'Office', icon: <Briefcase size={16} /> },
-  { emoji: '💪', label: 'Gym', icon: <Dumbbell size={16} /> },
-  { emoji: '☕', label: 'Cafe', icon: <Coffee size={16} /> },
-];
-
 interface MapPickerProps {
   location: Location | null;
   onLocationSelect: (location: Location) => void;
@@ -59,14 +54,12 @@ interface MapPickerProps {
 }
 
 export default function MapPicker({ location, onLocationSelect, className = '' }: MapPickerProps) {
-  const { savedAddresses, setSavedAddresses, addNotification } = useAppContext();
+  const { savedAddresses, addNotification } = useAppContext();
   const [isLoading, setIsLoading] = useState(false);
   const [showManual, setShowManual] = useState(false);
-  const [manualAddress, setManualAddress] = useState('');
   const [showSaveDialog, setShowSaveDialog] = useState(false);
-  const [saveLabel, setSaveLabel] = useState('');
-  const [saveEmoji, setSaveEmoji] = useState('🏠');
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
+
   const defaultCenter: [number, number] = [12.9716, 77.5946]; // Bangalore
   const center: [number, number] = location ? [location.lat, location.lng] : defaultCenter;
 
@@ -121,55 +114,24 @@ export default function MapPicker({ location, onLocationSelect, className = '' }
     }
   };
 
-  const handleManualSubmit = () => {
-    if (manualAddress.trim()) {
-      onLocationSelect({ lat: 0, lng: 0, address: manualAddress });
-      setShowManual(false);
-    }
+  const handleManualSubmit = (address: string) => {
+    onLocationSelect({ lat: 0, lng: 0, address });
+    setShowManual(false);
   };
 
-  const handleSavedAddressClick = (addr: typeof savedAddresses[0]) => {
+  const handleSavedAddressClick = (addr: any) => {
     onLocationSelect(addr.location);
     addNotification('Address Selected', `Using saved address: ${addr.label}`, 'info');
   };
 
-  const handleSaveAddress = () => {
-    if (!location || !saveLabel.trim()) return;
-    setSavedAddresses([
-      ...savedAddresses,
-      {
-        id: `addr-${Date.now()}`,
-        label: saveLabel.trim(),
-        emoji: saveEmoji,
-        location,
-      },
-    ]);
-    addNotification('Address Saved', `"${saveLabel}" has been saved to your address book.`, 'success');
-    setShowSaveDialog(false);
-    setSaveLabel('');
-  };
-
   return (
     <div className={`space-y-3 ${className}`}>
-      {/* Saved Address Chips (Feature 4) */}
-      {savedAddresses.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {savedAddresses.map((addr) => (
-            <button
-              key={addr.id}
-              onClick={() => handleSavedAddressClick(addr)}
-              className={`inline-flex items-center space-x-1.5 px-3 py-2 rounded-sm border-2 text-sm font-heading font-bold uppercase tracking-wider transition-all ${
-                location?.address === addr.location.address
-                  ? 'border-primary bg-primary/10 text-primary shadow-brutal-sm'
-                  : 'border-border bg-bg text-text hover:border-primary'
-              }`}
-            >
-              <span>{addr.emoji}</span>
-              <span>{addr.label}</span>
-            </button>
-          ))}
-        </div>
-      )}
+      {/* Saved Address Chips */}
+      <SavedAddressChips
+        savedAddresses={savedAddresses}
+        currentLocation={location}
+        onSelect={handleSavedAddressClick}
+      />
 
       <div className="relative rounded-sm overflow-hidden border-2 border-border" style={{ height: 200 }}>
         {isOffline ? (
@@ -218,73 +180,19 @@ export default function MapPicker({ location, onLocationSelect, className = '' }
         </div>
       )}
 
-      {/* Save Address Dialog (Feature 4) */}
-      <AnimatePresence>
-        {showSaveDialog && (
-          <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
-            className="overflow-hidden"
-          >
-            <div className="p-4 bg-surface border-2 border-primary rounded-sm space-y-3">
-              <div className="flex items-center justify-between">
-                <h4 className="font-heading font-bold text-text text-sm uppercase tracking-wider">Save Address</h4>
-                <button onClick={() => setShowSaveDialog(false)} className="text-muted hover:text-text transition-colors">
-                  <X size={16} />
-                </button>
-              </div>
-              <div className="flex gap-2">
-                {EMOJI_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.emoji}
-                    onClick={() => { setSaveEmoji(opt.emoji); setSaveLabel(opt.label); }}
-                    className={`flex-1 py-2 text-center rounded-sm border-2 transition-all ${
-                      saveEmoji === opt.emoji
-                        ? 'border-primary bg-primary/10 shadow-brutal-sm'
-                        : 'border-border bg-bg hover:border-muted'
-                    }`}
-                  >
-                    <span className="text-lg">{opt.emoji}</span>
-                    <p className="text-[10px] text-muted font-heading font-bold uppercase mt-1">{opt.label}</p>
-                  </button>
-                ))}
-              </div>
-              <input
-                type="text"
-                value={saveLabel}
-                onChange={(e) => setSaveLabel(e.target.value)}
-                placeholder="Address label (e.g., Home)"
-                className="input-brutal text-sm"
-              />
-              <button onClick={handleSaveAddress} disabled={!saveLabel.trim()} className="btn-primary w-full py-2 text-sm disabled:opacity-50">
-                <Bookmark size={14} className="mr-2" /> Save Address
-              </button>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* Save Address Dialog */}
+      <SaveAddressDialog
+        isOpen={showSaveDialog}
+        onClose={() => setShowSaveDialog(false)}
+        location={location}
+      />
 
-      {showManual && (
-        <div>
-          <textarea
-            value={manualAddress}
-            onChange={(e) => setManualAddress(e.target.value)}
-            placeholder="Enter complete delivery address..."
-            className="input-brutal resize-none h-20 mb-2"
-          />
-          <div className="flex space-x-2">
-            <button onClick={handleManualSubmit} className="btn-primary flex-1 py-2 text-sm">
-              Confirm Address
-            </button>
-            <button onClick={() => setShowManual(false)} className="btn-secondary flex-1 py-2 text-sm">
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
-
-      {!showManual && (
+      {showManual ? (
+        <ManualAddressEntry
+          onSubmit={handleManualSubmit}
+          onCancel={() => setShowManual(false)}
+        />
+      ) : (
         <div className="flex space-x-3">
           <button
             onClick={handleDetectGPS}

--- a/src/components/SaveAddressDialog.tsx
+++ b/src/components/SaveAddressDialog.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { Bookmark, X, Home, Briefcase, Dumbbell, Coffee } from 'lucide-react';
+import { Location } from '../types';
+import { useAppContext } from '../context/AppContext';
+
+export const EMOJI_OPTIONS = [
+  { emoji: '🏠', label: 'Home', icon: <Home size={16} /> },
+  { emoji: '🏢', label: 'Office', icon: <Briefcase size={16} /> },
+  { emoji: '💪', label: 'Gym', icon: <Dumbbell size={16} /> },
+  { emoji: '☕', label: 'Cafe', icon: <Coffee size={16} /> },
+];
+
+interface SaveAddressDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  location: Location | null;
+}
+
+export default function SaveAddressDialog({ isOpen, onClose, location }: SaveAddressDialogProps) {
+  const { savedAddresses, setSavedAddresses, addNotification } = useAppContext();
+  const [saveLabel, setSaveLabel] = useState('');
+  const [saveEmoji, setSaveEmoji] = useState('🏠');
+
+  const handleSaveAddress = () => {
+    if (!location || !saveLabel.trim()) return;
+    setSavedAddresses([
+      ...savedAddresses,
+      {
+        id: `addr-${Date.now()}`,
+        label: saveLabel.trim(),
+        emoji: saveEmoji,
+        location,
+      },
+    ]);
+    addNotification('Address Saved', `"${saveLabel}" has been saved to your address book.`, 'success');
+    onClose();
+    setSaveLabel('');
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          className="overflow-hidden"
+        >
+          <div className="p-4 bg-surface border-2 border-primary rounded-sm space-y-3">
+            <div className="flex items-center justify-between">
+              <h4 className="font-heading font-bold text-text text-sm uppercase tracking-wider">Save Address</h4>
+              <button onClick={onClose} className="text-muted hover:text-text transition-colors">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex gap-2">
+              {EMOJI_OPTIONS.map((opt) => (
+                <button
+                  key={opt.emoji}
+                  onClick={() => { setSaveEmoji(opt.emoji); setSaveLabel(opt.label); }}
+                  className={`flex-1 py-2 text-center rounded-sm border-2 transition-all ${
+                    saveEmoji === opt.emoji
+                      ? 'border-primary bg-primary/10 shadow-brutal-sm'
+                      : 'border-border bg-bg hover:border-muted'
+                  }`}
+                >
+                  <span className="text-lg">{opt.emoji}</span>
+                  <p className="text-[10px] text-muted font-heading font-bold uppercase mt-1">{opt.label}</p>
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={saveLabel}
+              onChange={(e) => setSaveLabel(e.target.value)}
+              placeholder="Address label (e.g., Home)"
+              className="input-brutal text-sm"
+            />
+            <button onClick={handleSaveAddress} disabled={!saveLabel.trim()} className="btn-primary w-full py-2 text-sm disabled:opacity-50">
+              <Bookmark size={14} className="mr-2" /> Save Address
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/SavedAddressChips.tsx
+++ b/src/components/SavedAddressChips.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Location } from '../types';
+
+interface SavedAddressChipsProps {
+  savedAddresses: any[];
+  currentLocation: Location | null;
+  onSelect: (addr: any) => void;
+}
+
+export default function SavedAddressChips({ savedAddresses, currentLocation, onSelect }: SavedAddressChipsProps) {
+  if (savedAddresses.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {savedAddresses.map((addr) => (
+        <button
+          key={addr.id}
+          onClick={() => onSelect(addr)}
+          className={`inline-flex items-center space-x-1.5 px-3 py-2 rounded-sm border-2 text-sm font-heading font-bold uppercase tracking-wider transition-all ${
+            currentLocation?.address === addr.location.address
+              ? 'border-primary bg-primary/10 text-primary shadow-brutal-sm'
+              : 'border-border bg-bg text-text hover:border-primary'
+          }`}
+        >
+          <span>{addr.emoji}</span>
+          <span>{addr.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
🎯 **What:** The `MapPicker.tsx` file was getting too long, so the logic for manual address entry, the save address dialog, and the saved address chips was extracted into separate, smaller components (`ManualAddressEntry.tsx`, `SaveAddressDialog.tsx`, `SavedAddressChips.tsx`). The main `MapPicker.tsx` file was updated to use these new components.
💡 **Why:** This improves the maintainability and readability of the codebase by breaking down a large, complex component into smaller, more focused, and reusable pieces. It also separates concerns more cleanly.
✅ **Verification:** I verified that the new components were correctly extracted and that the main component was correctly updated. I ran `npm run lint` and `npm run build` to ensure that the refactoring didn't introduce any TypeScript or build errors. Finally, I used a Playwright script to verify that the UI still renders correctly.
✨ **Result:** The `MapPicker.tsx` file is now significantly smaller and easier to read, while all existing functionality is preserved.

---
*PR created automatically by Jules for task [16591268598519488351](https://jules.google.com/task/16591268598519488351) started by @DhaatuTheGamer*