### PR TITLE
⚡ Bolt: Memoize expensive calculations in Home component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-17 - Unnecessary computations in Home component
+**Learning:** Derived state like filtered notifications or sorted arrays in React components can cause unnecessary recalculations on every re-render, especially when using complex hooks like `useAppContext` that trigger renders frequently.
+**Action:** Use `useMemo` for derived state calculations like sorting arrays or filtering lists to prevent re-computation when unrelated state changes.

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+// ⚡ Bolt: Memoized derived state to prevent unnecessary recalculations on re-renders
+import React, { useState, useMemo } from 'react';
 import { motion } from 'motion/react';
 import { MapPin, Bell, Fuel, Car, Clock, Settings, ArrowRight, AlertCircle, Droplets, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -8,9 +9,9 @@ import VehicleSelectModal from './VehicleSelectModal';
 export default function Home() {
   const { user, orders, notifications, vehicles, setCurrentOrder, addNotification } = useAppContext();
   const navigate = useNavigate();
-  const unreadCount = notifications.filter(n => !n.read).length;
-  const recentOrders = [...orders].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()).slice(0, 2);
-  const vehiclesWithReminders = vehicles.filter(v => v.tankCapacity && v.avgDailyKm);
+  const unreadCount = useMemo(() => notifications.filter(n => !n.read).length, [notifications]);
+  const recentOrders = useMemo(() => [...orders].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()).slice(0, 2), [orders]);
+  const vehiclesWithReminders = useMemo(() => vehicles.filter(v => v.tankCapacity && v.avgDailyKm), [vehicles]);
 
   const [showVehicleModal, setShowVehicleModal] = useState(false);
   const [pendingReorder, setPendingReorder] = useState<typeof orders[0] | null>(null);


### PR DESCRIPTION
💡 What: Used `useMemo` to memoize derived states (`unreadCount`, `recentOrders`, `vehiclesWithReminders`) in `src/components/Home.tsx` and added an explanatory comment.
🎯 Why: These derived states involve iterating over and creating new arrays (sorting, filtering, slicing) on every render of the `Home` component. This causes unnecessary recalculations and re-renders when other state changes (e.g., `showVehicleModal`).
📊 Impact: Prevents unnecessary computations and object/array instantiations on every re-render of the `Home` component, improving performance when interacting with modal states or unrelated context updates.
🔬 Measurement: Can be verified by measuring render times in React DevTools Profiler before and after the change when toggling the vehicle select modal.

---
*PR created automatically by Jules for task [2010146499659178407](https://jules.google.com/task/2010146499659178407) started by @DhaatuTheGamer*