### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-18 - Missing ARIA labels in icon-only buttons
+**Learning:** Found several icon-only buttons in the application lacking ARIA labels, creating accessibility issues for screen reader users. The application frequently uses Lucide React icons within `<button>` tags without any text content, particularly in close buttons (like 'X' icons in modals) and action toggles (like the SOS toggle or profile picture upload). This makes it difficult for visually impaired users to understand what action a button performs.
+**Action:** When creating new components with icon-only buttons, ensure an `aria-label` attribute is always included to provide context to assistive technologies.

--- a/src/components/CheckoutOffersSheet.tsx
+++ b/src/components/CheckoutOffersSheet.tsx
@@ -38,7 +38,7 @@ export default function CheckoutOffersSheet({ isOpen, onClose, onApplyOffer }: C
                 </div>
                 <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">Available Offers</h3>
               </div>
-              <button onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors">
                 <X size={20} />
               </button>
             </div>

--- a/src/components/EmergencyToggle.tsx
+++ b/src/components/EmergencyToggle.tsx
@@ -21,6 +21,7 @@ export default function EmergencyToggle({ isEmergency, onToggle }: EmergencyTogg
           </div>
         </div>
         <button
+          aria-label={isEmergency ? "Turn off emergency mode" : "Turn on emergency mode"}
           onClick={onToggle}
           className={`relative w-14 h-7 rounded-full border-2 border-border transition-colors ${isEmergency ? 'bg-red-500' : 'bg-bg'}`}
         >

--- a/src/components/Garage.tsx
+++ b/src/components/Garage.tsx
@@ -143,7 +143,7 @@ export default function Garage() {
             >
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-xl font-heading font-bold text-text uppercase tracking-wider">{editingId ? 'Edit Vehicle' : 'Add New Vehicle'}</h2>
-                <button onClick={cancelEdit} className="text-muted hover:text-text transition-colors">
+                <button aria-label="Cancel edit" onClick={cancelEdit} className="text-muted hover:text-text transition-colors">
                   <X size={24} />
                 </button>
               </div>

--- a/src/components/LiveTracking.tsx
+++ b/src/components/LiveTracking.tsx
@@ -311,10 +311,10 @@ export default function LiveTracking() {
                   </div>
                 </div>
                 <div className="flex space-x-2">
-                  <button className="w-10 h-10 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-text shadow-brutal-sm hover:bg-bg transition-colors">
+                  <button aria-label="Message Captain" className="w-10 h-10 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-text shadow-brutal-sm hover:bg-bg transition-colors">
                     <MessageSquare size={18} />
                   </button>
-                  <button className="w-10 h-10 bg-primary border-2 border-border rounded-sm flex items-center justify-center text-bg shadow-brutal-sm hover:bg-opacity-90 transition-colors">
+                  <button aria-label="Call Captain" className="w-10 h-10 bg-primary border-2 border-border rounded-sm flex items-center justify-center text-bg shadow-brutal-sm hover:bg-opacity-90 transition-colors">
                     <Phone size={18} />
                   </button>
                 </div>
@@ -361,7 +361,7 @@ export default function LiveTracking() {
                   </div>
                   <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">Need Help?</h3>
                 </div>
-                <button onClick={() => setShowSOS(false)} className="text-muted hover:text-text transition-colors">
+                <button aria-label="Close SOS" onClick={() => setShowSOS(false)} className="text-muted hover:text-text transition-colors">
                   <X size={20} />
                 </button>
               </div>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -72,7 +72,7 @@ export default function Profile() {
               {user?.name.charAt(0) || 'U'}
             </div>
             {isEditing && (
-              <button className="absolute -bottom-2 -right-2 w-8 h-8 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-primary shadow-brutal-sm hover:bg-bg transition-colors">
+              <button aria-label="Change profile picture" className="absolute -bottom-2 -right-2 w-8 h-8 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-primary shadow-brutal-sm hover:bg-bg transition-colors">
                 <Camera size={16} />
               </button>
             )}
@@ -156,10 +156,7 @@ export default function Profile() {
                 <p className="text-[10px] text-muted font-body uppercase tracking-wider">Your Referral Code</p>
                 <p className="font-heading font-bold text-text text-lg tracking-[0.2em]">{referralCode}</p>
               </div>
-              <button
-                onClick={handleCopyCode}
-                className="w-10 h-10 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-primary shadow-brutal-sm hover:bg-bg transition-colors"
-              >
+              <button aria-label="Copy referral code" onClick={handleCopyCode} className="w-10 h-10 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-primary shadow-brutal-sm hover:bg-bg transition-colors">
                 <Copy size={18} />
               </button>
             </div>

--- a/src/components/SaveAddressDialog.tsx
+++ b/src/components/SaveAddressDialog.tsx
@@ -50,7 +50,7 @@ export default function SaveAddressDialog({ isOpen, onClose, location }: SaveAdd
           <div className="p-4 bg-surface border-2 border-primary rounded-sm space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="font-heading font-bold text-text text-sm uppercase tracking-wider">Save Address</h4>
-              <button onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors">
                 <X size={16} />
               </button>
             </div>

--- a/src/components/VehicleSelectModal.tsx
+++ b/src/components/VehicleSelectModal.tsx
@@ -48,7 +48,7 @@ export default function VehicleSelectModal({ isOpen, onClose, onSelect, title = 
           >
             <div className="flex justify-between items-center mb-4">
               <h3 id="vehicle-select-title" className="text-lg font-heading font-bold text-text uppercase tracking-wider">{title}</h3>
-              <button onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors">
                 <X size={20} />
               </button>
             </div>

--- a/src/components/captain/CaptainDashboard.tsx
+++ b/src/components/captain/CaptainDashboard.tsx
@@ -438,7 +438,7 @@ export default function CaptainDashboard() {
                         <p className="text-xs text-muted font-body">{activeOrder.userPhone ? `+91 ${activeOrder.userPhone}` : '+91 XXXX XXXXX'}</p>
                       </div>
                     </div>
-                    <button className="w-10 h-10 bg-accent border-2 border-border rounded-sm flex items-center justify-center text-bg shadow-brutal-sm">
+                    <button aria-label="Call Customer" className="w-10 h-10 bg-accent border-2 border-border rounded-sm flex items-center justify-center text-bg shadow-brutal-sm">
                       <Phone size={18} />
                     </button>
                   </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to various icon-only `<button>` tags across the application.
🎯 Why: To improve accessibility for screen-reader users, as icon-only buttons lacked context and couldn't be easily understood.
📸 Before/After: N/A (Visual change only affects assistive technologies)
♿ Accessibility: Ensures that screen readers can clearly announce the purpose of actions like closing modals, toggling emergency states, uploading profile pictures, and communicating with the captain.

---
*PR created automatically by Jules for task [17412491257494345220](https://jules.google.com/task/17412491257494345220) started by @DhaatuTheGamer*