### PR TITLE
🎨 Palette: [Add ARIA labels to Settings page buttons]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-18 - Missing ARIA labels in icon-only buttons
 **Learning:** Found several icon-only buttons in the application lacking ARIA labels, creating accessibility issues for screen reader users. The application frequently uses Lucide React icons within `<button>` tags without any text content, particularly in close buttons (like 'X' icons in modals) and action toggles (like the SOS toggle or profile picture upload). This makes it difficult for visually impaired users to understand what action a button performs.
 **Action:** When creating new components with icon-only buttons, ensure an `aria-label` attribute is always included to provide context to assistive technologies.
+
+## 2024-03-20 - Dynamic ARIA labels on Toggle Buttons
+**Learning:** Found toggle buttons (like the dark mode toggle) that lacked ARIA labels. When components have internal state representing visual changes, providing static `aria-label` attributes isn't enough; the label must be dynamic to describe the *next* state or current state clearly to screen reader users.
+**Action:** When implementing toggles or switches, ensure `aria-label` utilizes the component's state to provide context-sensitive reading (e.g., `aria-label={isActive ? 'Deactivate' : 'Activate'}`).

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -10,7 +10,7 @@ export default function Settings() {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
           <ArrowLeft size={24} />
         </button>
         <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Settings</h1>
@@ -30,6 +30,7 @@ export default function Settings() {
               </div>
             </div>
             <button
+              aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
               onClick={() => setDarkMode(!darkMode)}
               className={`relative w-14 h-8 rounded-sm border-2 border-border transition-colors ${darkMode ? 'bg-primary' : 'bg-surface'}`}
             >


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the go back button and dark mode toggle switch on the Settings page.
🎯 Why: Without these labels, screen reader users would only hear "button" without understanding what action the button performs. This makes the interface confusing and inaccessible for visually impaired users.
📸 Before/After: Visuals haven't changed, but the markup now correctly supports assistive technologies. (Screenshot included in PR)
♿ Accessibility: Improved screen reader navigation on the Settings page by adding static and context-sensitive (dynamic) ARIA labels.

---
*PR created automatically by Jules for task [5860400360171382064](https://jules.google.com/task/5860400360171382064) started by @DhaatuTheGamer*