### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in OrderHistory

### DIFF
--- a/src/components/OrderHistory.tsx
+++ b/src/components/OrderHistory.tsx
@@ -62,12 +62,13 @@ export default function OrderHistory() {
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center justify-between sticky top-0 z-10 transition-colors">
         <div className="flex items-center">
-          <button onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+          <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
             <ArrowLeft size={24} />
           </button>
           <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Order History</h1>
         </div>
         <button
+          aria-label={showFilters ? 'Hide filters' : 'Show filters'}
           onClick={() => setShowFilters(!showFilters)}
           className={`p-2 border-2 rounded-sm transition-colors ${showFilters ? 'bg-primary text-bg border-border' : 'bg-bg text-text border-border hover:border-primary'}`}
         >


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the icon-only buttons in the `OrderHistory.tsx` component. The back button receives a static "Go back" label, while the filter toggle button receives a dynamic label ("Show filters" / "Hide filters") based on its state. Appended a learning entry to the `.jules/palette.md` journal.

🎯 **Why**: Icon-only buttons without text content are inaccessible to screen readers, providing no context for visually impaired users. Dynamic labels for toggle buttons further improve accessibility by communicating the current state/action.

📸 **Before/After**: Visually identical; accessibility improvement only.

♿ **Accessibility**: 
- Added `aria-label="Go back"` to `<ArrowLeft>` button.
- Added `aria-label={showFilters ? 'Hide filters' : 'Show filters'}` to `<Filter>` toggle button.

---
*PR created automatically by Jules for task [144580639040794418](https://jules.google.com/task/144580639040794418) started by @DhaatuTheGamer*