### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus state to star ratings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-03-20 - Dynamic ARIA labels on Toggle Buttons
 **Learning:** Found toggle buttons (like the dark mode toggle) that lacked ARIA labels. When components have internal state representing visual changes, providing static `aria-label` attributes isn't enough; the label must be dynamic to describe the *next* state or current state clearly to screen reader users.
 **Action:** When implementing toggles or switches, ensure `aria-label` utilizes the component's state to provide context-sensitive reading (e.g., `aria-label={isActive ? 'Deactivate' : 'Activate'}`).
+
+## 2024-05-15 - ARIA Labels on Interactive Rating Widgets
+**Learning:** Found that custom interactive widgets (like a star rating component built with icon buttons) lacked both proper descriptive `aria-label` attributes and keyboard focus styling (`focus-visible`). This makes it difficult for screen reader users to understand what the button represents and hard for keyboard users to see which star is currently focused.
+**Action:** Always provide descriptive `aria-label`s (e.g., `aria-label={\`Rate \${star} star\${star > 1 ? 's' : ''}\`}`) and `focus-visible` styles on custom interactive input elements.

--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -101,10 +101,11 @@ export default function Rating() {
             {[1, 2, 3, 4, 5].map((star) => (
               <button
                 key={star}
+                aria-label={`Rate ${star} star${star > 1 ? 's' : ''}`}
                 onMouseEnter={() => setHoveredRating(star)}
                 onMouseLeave={() => setHoveredRating(0)}
                 onClick={() => setRating(star)}
-                className="p-1 focus:outline-none transition-transform hover:scale-110"
+                className="p-1 focus:outline-none transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
               >
                 <Star
                   size={40}


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the star rating buttons in `src/components/Rating.tsx` and applied keyboard focus styling (`focus-visible:ring-2`).
🎯 **Why:** The star rating buttons were icon-only elements lacking an accessible name, making them unreadable to screen readers. Furthermore, keyboard users could not easily see which star was currently focused.
📸 **Before/After:** Before, the buttons had no labels or focus styles. After, they are announced as 'Rate 1 star', 'Rate 5 stars', etc., and show a clear primary-colored focus ring on keyboard navigation. 
♿ **Accessibility:** Fixes WCAG 4.1.2 Name, Role, Value and WCAG 2.4.7 Focus Visible violations on the interactive rating component.

---
*PR created automatically by Jules for task [14912586491901543473](https://jules.google.com/task/14912586491901543473) started by @DhaatuTheGamer*