### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to back buttons

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -8,7 +8,7 @@ export default function About() {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button onClick={() => navigate('/settings')} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate('/settings')} className="mr-4 text-text hover:text-primary transition-colors">
           <ArrowLeft size={24} />
         </button>
         <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">About</h1>

--- a/src/components/BulkOrder.tsx
+++ b/src/components/BulkOrder.tsx
@@ -89,7 +89,7 @@ export default function BulkOrder() {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
           <ArrowLeft size={24} />
         </button>
         <div className="flex items-center space-x-2">

--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -120,7 +120,7 @@ export default function Checkout() {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button onClick={() => navigate('/order')} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate('/order')} className="mr-4 text-text hover:text-primary transition-colors">
           <ArrowLeft size={24} />
         </button>
         <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Checkout</h1>

--- a/src/components/Garage.tsx
+++ b/src/components/Garage.tsx
@@ -116,7 +116,7 @@ export default function Garage() {
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center justify-between sticky top-0 z-10 transition-colors">
         <div className="flex items-center">
-          <button onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+          <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
             <ArrowLeft size={24} />
           </button>
           <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">My Garage</h1>

--- a/src/components/Legal.tsx
+++ b/src/components/Legal.tsx
@@ -69,7 +69,7 @@ export default function Legal({ type }: { type: 'privacy' | 'terms' }) {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button onClick={() => navigate(-1)} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate(-1)} className="mr-4 text-text hover:text-primary transition-colors">
           <ArrowLeft size={24} />
         </button>
         <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">{content.title}</h1>

--- a/src/components/OrderFuel.tsx
+++ b/src/components/OrderFuel.tsx
@@ -119,7 +119,7 @@ export default function OrderFuel() {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
           <ArrowLeft size={24} />
         </button>
         <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Order Fuel</h1>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -49,7 +49,7 @@ export default function Profile() {
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center justify-between sticky top-0 z-10 transition-colors">
         <div className="flex items-center">
-          <button onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+          <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
             <ArrowLeft size={24} />
           </button>
           <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Profile</h1>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Go back"` to the icon-only "back" buttons in `OrderFuel.tsx`, `About.tsx`, `BulkOrder.tsx`, `Profile.tsx`, `Legal.tsx`, `Checkout.tsx`, and `Garage.tsx`.
🎯 **Why:** To improve accessibility for screen reader users by providing text indicating the action performed by the icon-only back button.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Provided screen reader context for navigation back buttons.

---
*PR created automatically by Jules for task [8948982540686698117](https://jules.google.com/task/8948982540686698117) started by @DhaatuTheGamer*