### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-15 - ARIA Labels on Interactive Rating Widgets
 **Learning:** Found that custom interactive widgets (like a star rating component built with icon buttons) lacked both proper descriptive `aria-label` attributes and keyboard focus styling (`focus-visible`). This makes it difficult for screen reader users to understand what the button represents and hard for keyboard users to see which star is currently focused.
 **Action:** Always provide descriptive `aria-label`s (e.g., `aria-label={\`Rate \${star} star\${star > 1 ? 's' : ''}\`}`) and `focus-visible` styles on custom interactive input elements.
+## 2026-03-25 - Adding ARIA labels to icon buttons
+**Learning:** Found several icon-only buttons in the application lacking ARIA labels, creating accessibility issues for screen reader users. Added ARIA labels for buttons in FuelCart and MapPicker.
+**Action:** When creating new components with icon-only buttons, ensure an `aria-label` attribute is always included to provide context to assistive technologies.

--- a/src/components/FuelCart.tsx
+++ b/src/components/FuelCart.tsx
@@ -45,6 +45,7 @@ export default function FuelCart() {
         initial={{ scale: 0 }}
         animate={{ scale: 1 }}
         onClick={() => setIsOpen(true)}
+        aria-label="Open fuel cart"
         className="fixed bottom-6 right-6 z-40 w-14 h-14 bg-primary border-2 border-border rounded-sm shadow-brutal flex items-center justify-center text-bg hover:translate-y-[2px] hover:translate-x-[2px] hover:shadow-brutal-sm transition-all"
       >
         <ShoppingCart size={22} />
@@ -75,7 +76,7 @@ export default function FuelCart() {
                 <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">
                   Fuel Cart ({cart.length})
                 </h3>
-                <button onClick={() => setIsOpen(false)} className="text-muted hover:text-text transition-colors">
+                <button aria-label="Close cart" onClick={() => setIsOpen(false)} className="text-muted hover:text-text transition-colors">
                   <X size={20} />
                 </button>
               </div>
@@ -101,6 +102,7 @@ export default function FuelCart() {
                       <div className="flex items-center space-x-3">
                         <span className="font-heading font-bold text-text">₹{item.amountRupees.toFixed(0)}</span>
                         <button
+                          aria-label="Remove item"
                           onClick={() => handleRemoveItem(item.id)}
                           className="p-1 text-muted hover:text-red-500 transition-colors"
                         >

--- a/src/components/MapPicker.tsx
+++ b/src/components/MapPicker.tsx
@@ -167,6 +167,7 @@ export default function MapPicker({ location, onLocationSelect, className = '' }
           <p className="text-sm text-text font-body line-clamp-2 flex-1">{location.address}</p>
           {/* Save Address Button */}
           <button
+            aria-label="Save this address"
             onClick={() => setShowSaveDialog(true)}
             className="shrink-0 w-8 h-8 bg-surface border-2 border-border rounded-sm flex items-center justify-center text-primary hover:bg-bg transition-colors"
             title="Save this address"


### PR DESCRIPTION
💡 What: Added missing `aria-label`s to icon-only buttons in the FuelCart and MapPicker components.
🎯 Why: Enhances keyboard and screen-reader accessibility for visually impaired users.
♿ Accessibility: Provides explicit descriptions for screen readers on functional buttons (Open Cart, Close Cart, Remove Item, Save Address) that previously had no discernible text content.

---
*PR created automatically by Jules for task [9245187225897594089](https://jules.google.com/task/9245187225897594089) started by @DhaatuTheGamer*