### PR TITLE
🎨 Palette: [UX improvement] Add missing ARIA labels to icon-only buttons

### DIFF
--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -111,10 +111,10 @@ export default function Favorites() {
                       )}
                     </div>
                     <div className="flex space-x-1 shrink-0 ml-3">
-                      <button aria-label="Edit favorite" onClick={() => { setEditingId(fav.id); setEditName(fav.name); }} className="p-1.5 text-muted hover:text-primary transition-colors">
+                      <button aria-label={`Edit favorite ${fav.name}`} onClick={() => { setEditingId(fav.id); setEditName(fav.name); }} className="p-1.5 text-muted hover:text-primary transition-colors">
                         <Edit2 size={16} />
                       </button>
-                      <button aria-label="Delete favorite" onClick={() => setDeleteId(fav.id)} className="p-1.5 text-muted hover:text-red-500 transition-colors">
+                      <button aria-label={`Delete favorite ${fav.name}`} onClick={() => setDeleteId(fav.id)} className="p-1.5 text-muted hover:text-red-500 transition-colors">
                         <Trash2 size={16} />
                       </button>
                     </div>

--- a/src/components/Garage.tsx
+++ b/src/components/Garage.tsx
@@ -294,12 +294,14 @@ export default function Garage() {
                     </div>
                     <div className="flex space-x-2">
                       <button
+                        aria-label={`Edit ${vehicle.make} ${vehicle.model}`}
                         onClick={() => startEdit(vehicle)}
                         className="p-2 text-muted hover:text-primary transition-colors border-2 border-transparent hover:border-primary rounded-sm hover:bg-surface"
                       >
                         <Edit2 size={20} />
                       </button>
                       <button
+                        aria-label={`Delete ${vehicle.make} ${vehicle.model}`}
                         onClick={() => setVehicleToDelete(vehicle.id)}
                         className="p-2 text-muted hover:text-red-500 transition-colors border-2 border-transparent hover:border-red-500 rounded-sm hover:bg-surface"
                       >

--- a/src/components/NotificationToast.tsx
+++ b/src/components/NotificationToast.tsx
@@ -33,6 +33,7 @@ export default function NotificationToast() {
               <p className="text-sm text-muted font-body mt-0.5 leading-tight">{notification.message}</p>
             </div>
             <button 
+              aria-label="Close notification"
               onClick={() => markNotificationRead(notification.id)}
               className="ml-3 shrink-0 text-muted hover:text-primary transition-colors"
             >

--- a/src/components/SchedulePicker.tsx
+++ b/src/components/SchedulePicker.tsx
@@ -50,6 +50,7 @@ export default function SchedulePicker({ isScheduled, scheduledDate, onScheduleC
 
       <div className="flex p-1 bg-bg border-2 border-border rounded-sm mb-4 transition-colors">
         <button
+          aria-label="Order for now"
           onClick={() => {
             onScheduleChange(false, '');
             setSelectedSlot('');
@@ -61,6 +62,7 @@ export default function SchedulePicker({ isScheduled, scheduledDate, onScheduleC
           <Zap size={14} className="mr-1.5" /> Now
         </button>
         <button
+          aria-label="Schedule order for later"
           onClick={() => onScheduleChange(true, scheduledDate)}
           className={`flex-1 py-2.5 text-sm font-heading font-bold uppercase tracking-wider rounded-sm transition-all flex items-center justify-center ${
             isScheduled ? 'bg-primary text-bg border-2 border-border shadow-brutal-sm' : 'text-muted hover:text-text'
@@ -83,6 +85,7 @@ export default function SchedulePicker({ isScheduled, scheduledDate, onScheduleC
             <div className="grid grid-cols-4 gap-2">
               {days.map((day) => (
                 <button
+                  aria-label={`Select day ${day.label}`}
                   key={day.index}
                   onClick={() => {
                     setSelectedDay(day.index);
@@ -106,6 +109,7 @@ export default function SchedulePicker({ isScheduled, scheduledDate, onScheduleC
             <div className="grid grid-cols-2 gap-2">
               {timeSlots.length > 0 ? timeSlots.map((slot) => (
                 <button
+                  aria-label={`Select time slot ${slot.label}`}
                   key={slot.value}
                   onClick={() => handleSlotSelect(slot.value)}
                   className={`py-2.5 px-3 text-sm font-heading font-bold rounded-sm border-2 transition-all flex items-center justify-center ${


### PR DESCRIPTION
**💡 What:** Added descriptive `aria-label` attributes to various icon-only buttons across multiple components (`Garage.tsx`, `NotificationToast.tsx`, `SchedulePicker.tsx`, `Favorites.tsx`).

**🎯 Why:** Screen readers have difficulty understanding what an action button does when it contains only an icon (like an X for close, or a Trash can for delete). This change ensures that screen reader users hear a descriptive action (e.g., "Delete Honda Civic") rather than "button" or the icon's raw SVG contents.

**📸 Before/After:** N/A - The changes are purely structural and do not affect the visual presentation of the buttons.

**♿ Accessibility:** Improves navigation and understanding for screen reader users by providing context to previously unlabelled icon buttons.

---
*PR created automatically by Jules for task [10917009845219495394](https://jules.google.com/task/10917009845219495394) started by @DhaatuTheGamer*