### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard accessibility

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -66,13 +66,13 @@ export default function Home() {
           <button 
             onClick={() => navigate('/settings')}
             aria-label="Settings"
-            className="p-2 text-text border-2 border-border rounded-sm hover:border-primary hover:text-primary transition-colors bg-bg"
+            className="p-2 text-text border-2 border-border rounded-sm hover:border-primary hover:text-primary transition-colors bg-bg focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
           >
             <Settings size={20} />
           </button>
           <button
             aria-label="Notifications"
-            className="p-2 text-text border-2 border-border rounded-sm hover:border-primary hover:text-primary transition-colors bg-bg relative"
+            className="p-2 text-text border-2 border-border rounded-sm hover:border-primary hover:text-primary transition-colors bg-bg relative focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
           >
             <Bell size={20} />
             {unreadCount > 0 && (
@@ -95,7 +95,7 @@ export default function Home() {
             <h2 className="text-xl font-heading font-bold mb-4 line-clamp-1">Koramangala, Bangalore</h2>
             <button 
               onClick={() => navigate('/order')}
-              className="bg-bg text-text border-2 border-border px-6 py-3 rounded-sm font-heading font-bold text-sm uppercase tracking-wider shadow-brutal hover:translate-y-[2px] hover:translate-x-[2px] hover:shadow-brutal-sm transition-all inline-flex items-center"
+              className="bg-bg text-text border-2 border-border px-6 py-3 rounded-sm font-heading font-bold text-sm uppercase tracking-wider shadow-brutal hover:translate-y-[2px] hover:translate-x-[2px] hover:shadow-brutal-sm transition-all inline-flex items-center focus-visible:ring-2 focus-visible:ring-text focus-visible:outline-none"
             >
               Order Fuel Now <ArrowRight size={16} className="ml-2" />
             </button>
@@ -108,7 +108,7 @@ export default function Home() {
             animate={{ opacity: 1, x: 0 }}
             transition={{ delay: 0.1 }}
             onClick={() => navigate('/garage')}
-            className="card-brutal p-5 flex flex-col items-center justify-center text-center hover:border-primary transition-colors group"
+            className="card-brutal p-5 flex flex-col items-center justify-center text-center hover:border-primary transition-colors group focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
           >
             <div className="w-12 h-12 bg-bg border-2 border-border rounded-sm flex items-center justify-center mb-3 group-hover:scale-110 transition-transform shadow-brutal-sm">
               <Car size={24} className="text-primary" />
@@ -122,7 +122,7 @@ export default function Home() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.15 }}
             onClick={() => navigate('/fleet')}
-            className="card-brutal p-5 flex flex-col items-center justify-center text-center hover:border-primary transition-colors group"
+            className="card-brutal p-5 flex flex-col items-center justify-center text-center hover:border-primary transition-colors group focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
           >
             <div className="w-12 h-12 bg-bg border-2 border-border rounded-sm flex items-center justify-center mb-3 group-hover:scale-110 transition-transform shadow-brutal-sm">
               <Users size={24} className="text-primary" />
@@ -136,7 +136,7 @@ export default function Home() {
             animate={{ opacity: 1, x: 0 }}
             transition={{ delay: 0.2 }}
             onClick={() => navigate('/history')}
-            className="card-brutal p-5 flex flex-col items-center justify-center text-center hover:border-primary transition-colors group"
+            className="card-brutal p-5 flex flex-col items-center justify-center text-center hover:border-primary transition-colors group focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
           >
             <div className="w-12 h-12 bg-bg border-2 border-border rounded-sm flex items-center justify-center mb-3 group-hover:scale-110 transition-transform shadow-brutal-sm">
               <Clock size={24} className="text-primary" />
@@ -191,7 +191,7 @@ export default function Home() {
                       </div>
                       <button
                         onClick={() => navigate('/order')}
-                        className="text-xs font-heading font-bold bg-primary text-bg px-3 py-1.5 rounded-sm border-2 border-border shadow-brutal-sm hover:translate-y-px hover:shadow-none transition-all"
+                        className="text-xs font-heading font-bold bg-primary text-bg px-3 py-1.5 rounded-sm border-2 border-border shadow-brutal-sm hover:translate-y-px hover:shadow-none transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-2"
                       >
                         REFILL
                       </button>
@@ -210,7 +210,7 @@ export default function Home() {
         >
           <div className="flex items-center justify-between mb-4">
             <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">Recent Orders</h3>
-            <button onClick={() => navigate('/history')} className="text-sm text-primary font-heading font-bold uppercase tracking-wider hover:underline">See All</button>
+            <button onClick={() => navigate('/history')} className="text-sm text-primary font-heading font-bold uppercase tracking-wider hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">See All</button>
           </div>
           
           <div className="space-y-3">
@@ -240,7 +240,7 @@ export default function Home() {
                         e.stopPropagation();
                         handleReorder(order);
                       }}
-                      className="text-xs font-heading font-bold bg-surface border-2 border-border px-2 py-1 rounded-sm hover:bg-primary hover:text-bg transition-colors"
+                      className="text-xs font-heading font-bold bg-surface border-2 border-border px-2 py-1 rounded-sm hover:bg-primary hover:text-bg transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                     >
                       REORDER
                     </button>

--- a/src/components/OrderHistory.tsx
+++ b/src/components/OrderHistory.tsx
@@ -62,7 +62,7 @@ export default function OrderHistory() {
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center justify-between sticky top-0 z-10 transition-colors">
         <div className="flex items-center">
-          <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+          <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
             <ArrowLeft size={24} />
           </button>
           <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Order History</h1>
@@ -70,7 +70,7 @@ export default function OrderHistory() {
         <button
           aria-label={showFilters ? 'Hide filters' : 'Show filters'}
           onClick={() => setShowFilters(!showFilters)}
-          className={`p-2 border-2 rounded-sm transition-colors ${showFilters ? 'bg-primary text-bg border-border' : 'bg-bg text-text border-border hover:border-primary'}`}
+          className={`p-2 border-2 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${showFilters ? 'bg-primary text-bg border-border' : 'bg-bg text-text border-border hover:border-primary'}`}
         >
           <Filter size={20} />
         </button>
@@ -106,7 +106,7 @@ export default function OrderHistory() {
                       <button
                         key={status}
                         onClick={() => setSelectedStatus(status)}
-                        className={`px-3 py-1.5 border-2 rounded-sm text-xs font-heading font-bold uppercase tracking-wider transition-all ${
+                        className={`px-3 py-1.5 border-2 rounded-sm text-xs font-heading font-bold uppercase tracking-wider transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${
                           selectedStatus === status
                             ? 'bg-primary text-bg border-border shadow-brutal-sm'
                             : 'bg-bg border-border text-muted hover:border-muted'
@@ -122,7 +122,7 @@ export default function OrderHistory() {
                   <div className="flex space-x-2">
                     <button
                       onClick={() => setSortOrder('newest')}
-                      className={`flex-1 py-2 border-2 rounded-sm text-xs font-heading font-bold uppercase tracking-wider transition-all ${
+                      className={`flex-1 py-2 border-2 rounded-sm text-xs font-heading font-bold uppercase tracking-wider transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${
                         sortOrder === 'newest' ? 'bg-primary text-bg border-border shadow-brutal-sm' : 'bg-bg border-border text-muted'
                       }`}
                     >
@@ -130,7 +130,7 @@ export default function OrderHistory() {
                     </button>
                     <button
                       onClick={() => setSortOrder('oldest')}
-                      className={`flex-1 py-2 border-2 rounded-sm text-xs font-heading font-bold uppercase tracking-wider transition-all ${
+                      className={`flex-1 py-2 border-2 rounded-sm text-xs font-heading font-bold uppercase tracking-wider transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${
                         sortOrder === 'oldest' ? 'bg-primary text-bg border-border shadow-brutal-sm' : 'bg-bg border-border text-muted'
                       }`}
                     >
@@ -151,7 +151,7 @@ export default function OrderHistory() {
             </div>
             <h3 className="text-lg font-heading font-bold text-text mb-2 uppercase tracking-wider">No orders found</h3>
             <p className="text-muted font-body mb-4">{search ? 'Try a different search term' : 'Place your first order to see it here'}</p>
-            <button onClick={() => navigate('/order')} className="btn-primary px-6 py-3">
+            <button onClick={() => navigate('/order')} className="btn-primary px-6 py-3 focus-visible:ring-2 focus-visible:ring-text focus-visible:outline-none focus-visible:ring-offset-2">
               Order Fuel
             </button>
           </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -10,7 +10,7 @@ export default function Settings() {
   return (
     <div className="min-h-screen bg-bg flex flex-col transition-colors">
       <header className="bg-surface border-b-2 border-border px-6 py-4 flex items-center sticky top-0 z-10 transition-colors">
-        <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors">
+        <button aria-label="Go back" onClick={() => navigate('/')} className="mr-4 text-text hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
           <ArrowLeft size={24} />
         </button>
         <h1 className="font-heading font-bold text-xl text-text uppercase tracking-wider">Settings</h1>
@@ -32,7 +32,7 @@ export default function Settings() {
             <button
               aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
               onClick={() => setDarkMode(!darkMode)}
-              className={`relative w-14 h-8 rounded-sm border-2 border-border transition-colors ${darkMode ? 'bg-primary' : 'bg-surface'}`}
+              className={`relative w-14 h-8 rounded-sm border-2 border-border transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-2 ${darkMode ? 'bg-primary' : 'bg-surface'}`}
             >
               <div className={`absolute top-1 w-5 h-5 rounded-sm bg-bg border-2 border-border transition-all shadow-brutal-sm ${darkMode ? 'right-1' : 'left-1'}`} />
             </button>
@@ -41,7 +41,7 @@ export default function Settings() {
           {/* About */}
           <button
             onClick={() => navigate('/about')}
-            className="w-full p-4 flex items-center justify-between border-b-2 border-border hover:bg-bg transition-colors"
+            className="w-full p-4 flex items-center justify-between border-b-2 border-border hover:bg-bg transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:-outline-offset-2"
           >
             <div className="flex items-center">
               <div className="w-10 h-10 bg-bg border-2 border-border rounded-sm flex items-center justify-center text-text mr-3 transition-colors shadow-brutal-sm">
@@ -55,7 +55,7 @@ export default function Settings() {
           {/* Terms */}
           <button
             onClick={() => navigate('/terms')}
-            className="w-full p-4 flex items-center justify-between border-b-2 border-border hover:bg-bg transition-colors"
+            className="w-full p-4 flex items-center justify-between border-b-2 border-border hover:bg-bg transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:-outline-offset-2"
           >
             <div className="flex items-center">
               <div className="w-10 h-10 bg-bg border-2 border-border rounded-sm flex items-center justify-center text-text mr-3 transition-colors shadow-brutal-sm">
@@ -69,7 +69,7 @@ export default function Settings() {
           {/* Privacy */}
           <button
             onClick={() => navigate('/privacy')}
-            className="w-full p-4 flex items-center justify-between hover:bg-bg transition-colors"
+            className="w-full p-4 flex items-center justify-between hover:bg-bg transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:-outline-offset-2 rounded-b-sm"
           >
             <div className="flex items-center">
               <div className="w-10 h-10 bg-bg border-2 border-border rounded-sm flex items-center justify-center text-text mr-3 transition-colors shadow-brutal-sm">


### PR DESCRIPTION
💡 **What:** Added comprehensive `focus-visible` styling (typically `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none`) to numerous interactive elements including buttons, navigation links, and toggle switches across `Home.tsx`, `OrderHistory.tsx`, and `Settings.tsx`.

🎯 **Why:** To significantly improve keyboard accessibility. Many interactive elements lacked visual feedback when navigated to via the keyboard, making it difficult for users relying on non-mouse navigation to understand their current position on the page.

📸 **Before/After:**
*(Before)* Keyboard tabbing produced no visible outline on many buttons, such as the top nav icons or recent order items.
*(After)* Keyboard tabbing now clearly highlights the focused element with the primary brand color ring, as verified in local UI testing.

♿ **Accessibility:** Fixes WCAG 2.4.7 Focus Visible by ensuring all interactive elements have a clear, distinct focus indicator when navigated via keyboard.

---
*PR created automatically by Jules for task [10474110393870330441](https://jules.google.com/task/10474110393870330441) started by @DhaatuTheGamer*