### PR TITLE
🎨 Palette: Add aria-label to search input in OrderHistory

### DIFF
--- a/src/components/OrderHistory.tsx
+++ b/src/components/OrderHistory.tsx
@@ -85,6 +85,7 @@ export default function OrderHistory() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search orders..."
+            aria-label="Search orders"
             className="input-brutal pl-10"
           />
         </div>


### PR DESCRIPTION
* 💡 **What**: Added an `aria-label="Search orders"` attribute to the search input in the Order History component.
* 🎯 **Why**: Relying solely on the `placeholder` attribute for an input's accessible name is an accessibility anti-pattern. Placeholders disappear when text is typed and are inconsistently supported by screen readers. Adding an explicit `aria-label` ensures a persistent, reliable name for assistive technologies.
* 📸 **Before/After**: Visually identical, purely an accessibility enhancement.
* ♿ **Accessibility**: Improved screen reader experience by providing a clear, explicit name for the search input field.

---
*PR created automatically by Jules for task [2993921549838066510](https://jules.google.com/task/2993921549838066510) started by @DhaatuTheGamer*