### PR TITLE
🎨 Palette: Add focus visible styles to Order Fuel actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-03-25 - Adding ARIA labels to icon buttons
 **Learning:** Found several icon-only buttons in the application lacking ARIA labels, creating accessibility issues for screen reader users. Added ARIA labels for buttons in FuelCart and MapPicker.
 **Action:** When creating new components with icon-only buttons, ensure an `aria-label` attribute is always included to provide context to assistive technologies.
+
+## 2026-03-28 - Focus Visible Styles for Quick Actions and Primary CTAs
+**Learning:** Found that secondary quick-action buttons (like the quick amount/quantity selectors in the OrderFuel component) and primary calls to actions (like 'Continue to Checkout' or 'Add to Cart') lacked explicit keyboard focus styling. Because they use a brutalist design system with complex borders and shadow changes on hover, the default browser focus ring is often insufficient or entirely overwritten, making keyboard navigation confusing.
+**Action:** Always provide explicit `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none` (and `focus-visible:ring-offset-2` when appropriate to separate the ring from the border) on all interactive buttons, especially those that act as primary user flows or quick selection helpers, to ensure they remain accessible to keyboard users.

--- a/src/components/OrderFuel.tsx
+++ b/src/components/OrderFuel.tsx
@@ -215,7 +215,7 @@ export default function OrderFuel() {
               <button
                 key={quickValue}
                 onClick={() => setValue(quickValue.toString())}
-                className="flex-1 py-2 bg-surface border-2 border-border rounded-sm font-heading font-bold text-sm hover:bg-bg hover:border-primary transition-colors"
+                className="flex-1 py-2 bg-surface border-2 border-border rounded-sm font-heading font-bold text-sm hover:bg-bg hover:border-primary transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
               >
             {orderType === 'amount' ? `₹${quickValue}` : `${quickValue}L`}
               </button>
@@ -300,14 +300,14 @@ export default function OrderFuel() {
           {vehicles.length > 1 && (
             <button
               onClick={handleAddToCart}
-              className="btn-secondary w-full py-4 text-base flex items-center justify-center"
+              className="btn-secondary w-full py-4 text-base flex items-center justify-center focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-2"
             >
               <Plus size={18} className="mr-2" /> Add to Cart & Select Another Vehicle
             </button>
           )}
           <button
             onClick={handleContinue}
-            className="btn-primary w-full py-4 text-lg flex items-center justify-center"
+            className="btn-primary w-full py-4 text-lg flex items-center justify-center focus-visible:ring-2 focus-visible:ring-text focus-visible:outline-none focus-visible:ring-offset-2"
           >
             Continue to Checkout <ArrowRight size={20} className="ml-2" />
           </button>


### PR DESCRIPTION
### 💡 What
Added explicit `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none`) to the interactive buttons within the `OrderFuel` component.

### 🎯 Why
Because the application uses a brutalist design system with complex borders and shadow changes on hover, the default browser focus ring was often insufficient or entirely overwritten on these buttons. This made keyboard navigation confusing as users couldn't clearly see which action they were focused on. 

### 📸 Before/After
*(See Playwright verification screenshots for demonstration)*
Before: Keyboard tabbing to the quick amount selectors or primary buttons resulted in no visible change to the element.
After: Keyboard tabbing to the buttons now clearly outlines them with the primary theme color.

### ♿ Accessibility
Improved keyboard accessibility (WCAG 2.1 SC 2.4.7 Focus Visible) by ensuring all primary and secondary interactive elements in the crucial ordering flow have a highly visible focus indicator that works well with the existing custom styling.

---
*PR created automatically by Jules for task [8395701548949568402](https://jules.google.com/task/8395701548949568402) started by @DhaatuTheGamer*