### PR TITLE
🧹 remove unnecessary 'as any' casting for event listener

### DIFF
--- a/src/components/CheckoutConfirmModal.tsx
+++ b/src/components/CheckoutConfirmModal.tsx
@@ -33,8 +33,8 @@ export default function CheckoutConfirmModal({
   // Close on Escape
   useEffect(() => {
     const handleEscape = () => onClose();
-    document.addEventListener('modal-escape' as any, handleEscape);
-    return () => document.removeEventListener('modal-escape' as any, handleEscape);
+    document.addEventListener('modal-escape', handleEscape);
+    return () => document.removeEventListener('modal-escape', handleEscape);
   }, [onClose]);
 
   return (

--- a/src/components/Garage.tsx
+++ b/src/components/Garage.tsx
@@ -108,8 +108,8 @@ export default function Garage() {
   // Close delete modal on Escape (Feature 8)
   useEffect(() => {
     const handleEscape = () => setVehicleToDelete(null);
-    document.addEventListener('modal-escape' as any, handleEscape);
-    return () => document.removeEventListener('modal-escape' as any, handleEscape);
+    document.addEventListener('modal-escape', handleEscape);
+    return () => document.removeEventListener('modal-escape', handleEscape);
   }, []);
 
   return (

--- a/src/components/VehicleSelectModal.tsx
+++ b/src/components/VehicleSelectModal.tsx
@@ -21,8 +21,8 @@ export default function VehicleSelectModal({ isOpen, onClose, onSelect, title = 
   useEffect(() => {
     if (!isOpen) return;
     const handleEscape = () => onClose();
-    document.addEventListener('modal-escape' as any, handleEscape);
-    return () => document.removeEventListener('modal-escape' as any, handleEscape);
+    document.addEventListener('modal-escape', handleEscape);
+    return () => document.removeEventListener('modal-escape', handleEscape);
   }, [isOpen, onClose]);
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,3 +86,9 @@ export interface SavedAddress {
   emoji: string;
   location: Location;
 }
+
+declare global {
+  interface DocumentEventMap {
+    'modal-escape': CustomEvent;
+  }
+}


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `as any` type casting when adding or removing event listeners for the custom `'modal-escape'` event.

💡 **Why:** This improves maintainability and type safety by properly extending the global `DocumentEventMap` interface in TypeScript. It provides better developer experience through autocomplete and prevents future need for unsafe casting.

✅ **Verification:** 
- Conducted manual inspection of the code changes.
- Performed a search for all occurrences of `'modal-escape'` to ensure consistent application of the fix across the codebase.
- Verified the solution with a code review.
- (Note: Full automated type checking and testing were attempted but blocked by external dependency installation timeouts).

✨ **Result:** A cleaner, more type-safe codebase with better IDE support for custom events.

---
*PR created automatically by Jules for task [16158972871720641194](https://jules.google.com/task/16158972871720641194) started by @DhaatuTheGamer*