### PR TITLE
🧪 test: add error path test for orderBridge.read JSON parsing

### DIFF
--- a/src/services/orderBridge.test.ts
+++ b/src/services/orderBridge.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, mock, afterEach } from 'bun:test';
+import './setup-bun';
+import {
+  getActiveOrders,
+  publishOrder,
+  updateOrderStatus,
+  removeOrder,
+  onOrderChange
+} from './orderBridge';
+import { Order } from '../types';
+
+const STORAGE_KEY = 'fd_active_orders';
+
+describe('orderBridge', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mock.restore();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('getActiveOrders', () => {
+    it('should return an empty array when localStorage is empty', () => {
+      expect(getActiveOrders()).toEqual([]);
+    });
+
+    it('should return orders when localStorage has valid JSON', () => {
+      const orders: Order[] = [
+        { id: '1', status: 'Pending' } as Order
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(orders));
+      expect(getActiveOrders()).toEqual(orders);
+    });
+
+    it('should return an empty array when localStorage contains invalid JSON', () => {
+      localStorage.setItem(STORAGE_KEY, '{invalid}');
+      expect(getActiveOrders()).toEqual([]);
+    });
+  });
+
+  describe('publishOrder', () => {
+    it('should add a new order to localStorage', () => {
+      const order: Order = { id: '1', status: 'Pending' } as Order;
+      publishOrder(order);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(stored).toEqual([order]);
+    });
+
+    it('should update an existing order in localStorage', () => {
+      const order1: Order = { id: '1', status: 'Pending' } as Order;
+      const order2: Order = { id: '1', status: 'Accepted' } as Order;
+      publishOrder(order1);
+      publishOrder(order2);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(stored).toEqual([order2]);
+    });
+
+    it('should dispatch fd-order-change custom event', () => {
+      const dispatchSpy = mock(window.dispatchEvent);
+      window.dispatchEvent = dispatchSpy;
+
+      const order: Order = { id: '1', status: 'Pending' } as Order;
+      publishOrder(order);
+      expect(dispatchSpy).toHaveBeenCalled();
+      const event = dispatchSpy.mock.calls.find(call => (call[0] as any).type === 'fd-order-change')?.[0] as any;
+      expect(event).toBeDefined();
+      expect(event.detail).toEqual([order]);
+    });
+  });
+
+  describe('updateOrderStatus', () => {
+    it('should update the status and captain name of an existing order', () => {
+      const order: Order = { id: '1', status: 'Pending' } as Order;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([order]));
+
+      updateOrderStatus('1', 'Accepted', 'Captain Hook');
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(stored[0].status).toBe('Accepted');
+      expect(stored[0].captainName).toBe('Captain Hook');
+    });
+
+    it('should do nothing if the order ID is not found', () => {
+      const order: Order = { id: '1', status: 'Pending' } as Order;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([order]));
+
+      updateOrderStatus('2', 'Accepted');
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(stored).toEqual([order]);
+    });
+  });
+
+  describe('removeOrder', () => {
+    it('should remove an order from localStorage by ID', () => {
+      const orders: Order[] = [
+        { id: '1' } as Order,
+        { id: '2' } as Order
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(orders));
+
+      removeOrder('1');
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(stored).toEqual([{ id: '2' }]);
+    });
+  });
+
+  describe('onOrderChange', () => {
+    it('should trigger callback on storage events', () => {
+      const callback = mock(() => {});
+      onOrderChange(callback);
+
+      const orders: Order[] = [{ id: '1' } as Order];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(orders));
+
+      const storageEvent = new (global as any).StorageEvent('storage', {
+        key: STORAGE_KEY,
+        newValue: JSON.stringify(orders)
+      });
+      window.dispatchEvent(storageEvent);
+
+      expect(callback).toHaveBeenCalledWith(orders);
+    });
+
+    it('should trigger callback on fd-order-change events', () => {
+      const callback = mock(() => {});
+      onOrderChange(callback);
+
+      const orders: Order[] = [{ id: '1' } as Order];
+      const customEvent = new (global as any).CustomEvent('fd-order-change', { detail: orders });
+      window.dispatchEvent(customEvent);
+
+      expect(callback).toHaveBeenCalledWith(orders);
+    });
+
+    it('should return an unsubscribe function that removes listeners', () => {
+      const addSpy = mock(window.addEventListener);
+      const removeSpy = mock(window.removeEventListener);
+      window.addEventListener = addSpy;
+      window.removeEventListener = removeSpy;
+
+      const unsubscribe = onOrderChange(() => {});
+      expect(addSpy).toHaveBeenCalled();
+
+      unsubscribe();
+      expect(removeSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/setup-bun.ts
+++ b/src/services/setup-bun.ts
@@ -1,0 +1,54 @@
+
+const store = new Map();
+const listeners = new Map();
+
+global.localStorage = {
+  getItem: (key) => store.has(key) ? store.get(key) : null,
+  setItem: (key, value) => store.set(key, String(value)),
+  clear: () => store.clear(),
+  removeItem: (key) => store.delete(key),
+  get length() { return store.size; },
+  key: (index) => Array.from(store.keys())[index] || null,
+};
+
+global.window = {
+  dispatchEvent: (event) => {
+    const type = event.type;
+    if (listeners.has(type)) {
+      listeners.get(type).forEach(cb => cb(event));
+    }
+    return true;
+  },
+  addEventListener: (type, listener) => {
+    if (!listeners.has(type)) listeners.set(type, []);
+    listeners.get(type).push(listener);
+  },
+  removeEventListener: (type, listener) => {
+    if (listeners.has(type)) {
+      const list = listeners.get(type);
+      const idx = list.indexOf(listener);
+      if (idx !== -1) list.splice(idx, 1);
+    }
+  },
+};
+
+global.CustomEvent = class {
+  constructor(type, options) {
+    this.type = type;
+    this.detail = options?.detail;
+  }
+};
+
+global.StorageEvent = class {
+  constructor(type, options) {
+    this.type = type;
+    this.key = options?.key;
+    this.newValue = options?.newValue;
+  }
+};
+
+global.Event = class {
+  constructor(type) {
+    this.type = type;
+  }
+};


### PR DESCRIPTION
This PR addresses a testing gap in `src/services/orderBridge.ts` by adding a test case for the error path in `localStorage` JSON parsing.

🎯 **What:** 
- Created `src/services/orderBridge.test.ts` to test the `orderBridge` service.
- Created `src/services/setup-bun.ts` to mock DOM globals (`localStorage`, `window`, `CustomEvent`, etc.) for `bun test`.

📊 **Coverage:** 
- Scenarios now tested include:
    - `getActiveOrders`: empty storage, valid JSON, and **invalid JSON (the identified gap)**.
    - `publishOrder`: new order, updating existing order, and event dispatching.
    - `updateOrderStatus`: successful update and non-existent order.
    - `removeOrder`: removing by ID.
    - `onOrderChange`: handling `storage` and custom `fd-order-change` events, plus unsubscription.

✨ **Result:** 
- Increased test coverage for core service logic.
- Robust verification of error handling in `orderBridge.read`.
- Established a pattern for running tests with `bun test` when standard Vitest environments are unavailable.

---
*PR created automatically by Jules for task [16743211526671032895](https://jules.google.com/task/16743211526671032895) started by @DhaatuTheGamer*