### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible styling to utility icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-03-30 - Focus Visible Styles for Back Buttons
 **Learning:** Found that the 'Go back' buttons (often represented by a left arrow icon) across various components (Favorites, OrderFuel, About, BulkOrder, Profile, Legal, Checkout, Garage) lacked explicit keyboard focus styling. While some components like Settings and OrderHistory had them (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm`), many did not, making keyboard navigation inconsistent and confusing.
 **Action:** Consistently apply explicit `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm` to all navigation icon buttons like 'Go back' to ensure they remain accessible to keyboard users.
+
+## 2026-04-01 - Focus Visible Styles for Modal and Utility Icon Buttons
+**Learning:** Found that secondary utility icon buttons (like 'X' to close modals, 'Trash' to delete list items, or 'Edit' pens) often lack explicit `focus-visible` styling, just like primary buttons. Because these are often transparent or use subtle hover effects, native browser focus rings can be hard to see or disabled entirely, making it very difficult for keyboard users to navigate complex interactive elements (like carts or lists).
+**Action:** Consistently apply explicit `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm` (matching the button's border radius) to all utility icon buttons, especially those that trigger destructive actions or close overlays.

--- a/src/components/BulkOrder.tsx
+++ b/src/components/BulkOrder.tsx
@@ -140,7 +140,7 @@ export default function BulkOrder() {
                             {vehicle ? `${vehicle.make} ${vehicle.model}` : 'Unknown'}
                           </span>
                         </div>
-                        <button onClick={() => removeItem(item.id)} className="text-muted hover:text-red-500 transition-colors">
+                        <button aria-label="Remove item" onClick={() => removeItem(item.id)} className="text-muted hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                           <Trash2 size={16} />
                         </button>
                       </div>

--- a/src/components/CheckoutOffersSheet.tsx
+++ b/src/components/CheckoutOffersSheet.tsx
@@ -38,7 +38,7 @@ export default function CheckoutOffersSheet({ isOpen, onClose, onApplyOffer }: C
                 </div>
                 <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">Available Offers</h3>
               </div>
-              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                 <X size={20} />
               </button>
             </div>

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -111,10 +111,10 @@ export default function Favorites() {
                       )}
                     </div>
                     <div className="flex space-x-1 shrink-0 ml-3">
-                      <button aria-label={`Edit favorite ${fav.name}`} onClick={() => { setEditingId(fav.id); setEditName(fav.name); }} className="p-1.5 text-muted hover:text-primary transition-colors">
+                      <button aria-label={`Edit favorite ${fav.name}`} onClick={() => { setEditingId(fav.id); setEditName(fav.name); }} className="p-1.5 text-muted hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                         <Edit2 size={16} />
                       </button>
-                      <button aria-label={`Delete favorite ${fav.name}`} onClick={() => setDeleteId(fav.id)} className="p-1.5 text-muted hover:text-red-500 transition-colors">
+                      <button aria-label={`Delete favorite ${fav.name}`} onClick={() => setDeleteId(fav.id)} className="p-1.5 text-muted hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                         <Trash2 size={16} />
                       </button>
                     </div>

--- a/src/components/FuelCart.tsx
+++ b/src/components/FuelCart.tsx
@@ -76,7 +76,7 @@ export default function FuelCart() {
                 <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">
                   Fuel Cart ({cart.length})
                 </h3>
-                <button aria-label="Close cart" onClick={() => setIsOpen(false)} className="text-muted hover:text-text transition-colors">
+                <button aria-label="Close cart" onClick={() => setIsOpen(false)} className="text-muted hover:text-text transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                   <X size={20} />
                 </button>
               </div>
@@ -104,7 +104,7 @@ export default function FuelCart() {
                         <button
                           aria-label="Remove item"
                           onClick={() => handleRemoveItem(item.id)}
-                          className="p-1 text-muted hover:text-red-500 transition-colors"
+                          className="p-1 text-muted hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm"
                         >
                           <Trash2 size={16} />
                         </button>

--- a/src/components/Garage.tsx
+++ b/src/components/Garage.tsx
@@ -143,7 +143,7 @@ export default function Garage() {
             >
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-xl font-heading font-bold text-text uppercase tracking-wider">{editingId ? 'Edit Vehicle' : 'Add New Vehicle'}</h2>
-                <button aria-label="Cancel edit" onClick={cancelEdit} className="text-muted hover:text-text transition-colors">
+                <button aria-label="Cancel edit" onClick={cancelEdit} className="text-muted hover:text-text transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                   <X size={24} />
                 </button>
               </div>
@@ -296,14 +296,14 @@ export default function Garage() {
                       <button
                         aria-label={`Edit ${vehicle.make} ${vehicle.model}`}
                         onClick={() => startEdit(vehicle)}
-                        className="p-2 text-muted hover:text-primary transition-colors border-2 border-transparent hover:border-primary rounded-sm hover:bg-surface"
+                        className="p-2 text-muted hover:text-primary transition-colors border-2 border-transparent hover:border-primary rounded-sm hover:bg-surface focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                       >
                         <Edit2 size={20} />
                       </button>
                       <button
                         aria-label={`Delete ${vehicle.make} ${vehicle.model}`}
                         onClick={() => setVehicleToDelete(vehicle.id)}
-                        className="p-2 text-muted hover:text-red-500 transition-colors border-2 border-transparent hover:border-red-500 rounded-sm hover:bg-surface"
+                        className="p-2 text-muted hover:text-red-500 transition-colors border-2 border-transparent hover:border-red-500 rounded-sm hover:bg-surface focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                       >
                         <Trash2 size={20} />
                       </button>

--- a/src/components/LiveTracking.tsx
+++ b/src/components/LiveTracking.tsx
@@ -361,7 +361,7 @@ export default function LiveTracking() {
                   </div>
                   <h3 className="font-heading font-bold text-lg text-text uppercase tracking-wider">Need Help?</h3>
                 </div>
-                <button aria-label="Close SOS" onClick={() => setShowSOS(false)} className="text-muted hover:text-text transition-colors">
+                <button aria-label="Close SOS" onClick={() => setShowSOS(false)} className="text-muted hover:text-text transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                   <X size={20} />
                 </button>
               </div>

--- a/src/components/NotificationToast.tsx
+++ b/src/components/NotificationToast.tsx
@@ -35,7 +35,7 @@ export default function NotificationToast() {
             <button 
               aria-label="Close notification"
               onClick={() => markNotificationRead(notification.id)}
-              className="ml-3 shrink-0 text-muted hover:text-primary transition-colors"
+              className="ml-3 shrink-0 text-muted hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm"
             >
               <X size={18} />
             </button>

--- a/src/components/SaveAddressDialog.tsx
+++ b/src/components/SaveAddressDialog.tsx
@@ -50,7 +50,7 @@ export default function SaveAddressDialog({ isOpen, onClose, location }: SaveAdd
           <div className="p-4 bg-surface border-2 border-primary rounded-sm space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="font-heading font-bold text-text text-sm uppercase tracking-wider">Save Address</h4>
-              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                 <X size={16} />
               </button>
             </div>

--- a/src/components/VehicleSelectModal.tsx
+++ b/src/components/VehicleSelectModal.tsx
@@ -48,7 +48,7 @@ export default function VehicleSelectModal({ isOpen, onClose, onSelect, title = 
           >
             <div className="flex justify-between items-center mb-4">
               <h3 id="vehicle-select-title" className="text-lg font-heading font-bold text-text uppercase tracking-wider">{title}</h3>
-              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <button aria-label="Close" onClick={onClose} className="text-muted hover:text-text transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm">
                 <X size={20} />
               </button>
             </div>


### PR DESCRIPTION
### 💡 What: 
Added explicit keyboard focus styling (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-sm`) to secondary utility icon buttons across the application (e.g., 'X' to close modals, 'Trash' to delete items, 'Edit' pens).

### 🎯 Why:
Because these utility buttons often have transparent backgrounds and rely on subtle hover effects in the brutalist design system, the default browser focus ring is either insufficient, hidden, or clashing. This makes it very difficult for keyboard users and those relying on assistive technologies to see which utility action is currently focused, particularly inside complex components like lists or modals.

### 📸 Before/After:
Before: Tabbing to the edit or delete icon button on a saved favorite would not provide a clear visual indicator that the button was focused.
After: Tabbing to these buttons now shows a clear, primary-colored focus ring that matches the button's border radius, making navigation clear.

### ♿ Accessibility:
- Significantly improves keyboard accessibility by providing explicit, high-contrast focus indicators for interactive utility elements.
- Added a missing `aria-label` to the 'Remove item' button within the BulkOrder component.

---
*PR created automatically by Jules for task [1244639872652554326](https://jules.google.com/task/1244639872652554326) started by @DhaatuTheGamer*