### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to primary input fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,7 @@
 ## 2024-03-20 - Accessible Custom Checkboxes in Brutalist Design
 **Learning:** Custom checkboxes built with `<button>` elements (like in `SafetyChecklist`) need explicit semantic roles (`role="checkbox"`), state attributes (`aria-checked`), and distinct keyboard focus styles (`focus-visible:ring-primary focus-visible:ring-offset-2`) to be accessible, especially against thick brutalist borders.
 **Action:** Always verify that interactive elements disguised as standard controls have full ARIA state management and use the application's standard focus rings to ensure keyboard navigability.
+
+## 2024-05-18 - Missing ARIA Labels on Primary Inputs
+**Learning:** Found that primary input fields in forms (like Mobile Number, OTP in `Login.tsx`, and amount/quantity in `OrderFuel.tsx`) lacked programmatic association with their visible labels, which is a critical accessibility issue.
+**Action:** When adding or reviewing input fields, ensure they always have an explicit `aria-label` or are associated with an `<label htmlFor="...">` element, especially when dynamic labels (like "Enter amount in rupees" vs "Enter volume in liters") are needed.

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -102,6 +102,7 @@ export default function Login() {
                   type="tel"
                   value={phone}
                   onChange={(e) => setPhone(e.target.value.replace(/\D/g, '').slice(0, 10))}
+                  aria-label="Mobile Number"
                   className="input-brutal rounded-l-none"
                   placeholder="Enter 10 digit number"
                   required
@@ -137,6 +138,7 @@ export default function Login() {
                 type="text"
                 value={otp}
                 onChange={(e) => setOtp(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                aria-label="Enter OTP"
                 className="input-brutal text-center tracking-widest text-2xl font-heading"
                 placeholder="1234"
                 required

--- a/src/components/OrderFuel.tsx
+++ b/src/components/OrderFuel.tsx
@@ -200,6 +200,7 @@ export default function OrderFuel() {
               type="number"
               value={value}
               onChange={(e) => setValue(e.target.value)}
+              aria-label={orderType === 'amount' ? 'Enter amount in rupees' : 'Enter volume in liters'}
               className="w-full pl-12 pr-16 py-4 rounded-sm border-2 border-border bg-bg text-text font-heading font-bold text-xl focus:border-primary focus:ring-0 outline-none transition-colors"
               placeholder={orderType === 'amount' ? 'Enter amount' : 'Enter liters'}
             />


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the main `<input>` fields in `src/components/Login.tsx` (Mobile Number, OTP) and `src/components/OrderFuel.tsx` (dynamic label for amount/liters).
🎯 **Why**: These input fields lacked explicit programmatic association with their visible labels or placeholders, which is an accessibility anti-pattern. Adding `aria-label` improves screen reader compatibility.
📸 **Before/After**: N/A (Visuals remain the same, changes only impact screen readers).
♿ **Accessibility**: Improved programmatic association for screen reader users by ensuring the primary interactive input elements have explicit context.

---
*PR created automatically by Jules for task [1651041371599168824](https://jules.google.com/task/1651041371599168824) started by @DhaatuTheGamer*