### PR TITLE
🎨 Palette: Enhance keyboard accessibility for custom form controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,7 @@
 ## 2024-05-18 - Missing ARIA Labels on Primary Inputs
 **Learning:** Found that primary input fields in forms (like Mobile Number, OTP in `Login.tsx`, and amount/quantity in `OrderFuel.tsx`) lacked programmatic association with their visible labels, which is a critical accessibility issue.
 **Action:** When adding or reviewing input fields, ensure they always have an explicit `aria-label` or are associated with an `<label htmlFor="...">` element, especially when dynamic labels (like "Enter amount in rupees" vs "Enter volume in liters") are needed.
+
+## 2025-04-03 - Custom Radio Buttons Accessibility
+**Learning:** Using `className="hidden"` on native `<input type="radio">` removes them completely from the DOM tab order, breaking keyboard navigation for custom-styled radio options.
+**Action:** Always use `sr-only` instead of `hidden` for native inputs within custom components. To style the parent `<label>` when the native input receives focus, utilize Tailwind's `has-[:focus-visible]:ring-2` (and related `has-[:focus-visible]:*` utilities).

--- a/src/components/CheckoutPaymentMethods.tsx
+++ b/src/components/CheckoutPaymentMethods.tsx
@@ -16,10 +16,10 @@ export default function CheckoutPaymentMethods({ paymentMethod, setPaymentMethod
           { id: 'card', label: 'Credit / Debit Card', icon: <CreditCard size={20} /> },
           { id: 'cash', label: 'Cash on Delivery', icon: <Wallet size={20} /> },
         ].map(method => (
-          <label key={method.id} className={`flex items-center justify-between p-4 rounded-sm border-2 cursor-pointer transition-all ${
+          <label key={method.id} className={`flex items-center justify-between p-4 rounded-sm border-2 cursor-pointer transition-all has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:outline-none has-[:focus-visible]:ring-offset-2 ${
             paymentMethod === method.id ? 'border-primary bg-surface shadow-brutal-sm' : 'border-border bg-bg hover:border-muted'
           }`}>
-            <input type="radio" name="payment" value={method.id} checked={paymentMethod === method.id} onChange={() => setPaymentMethod(method.id)} className="hidden" />
+            <input type="radio" name="payment" value={method.id} checked={paymentMethod === method.id} onChange={() => setPaymentMethod(method.id)} className="sr-only" />
             <div className="flex items-center space-x-3">
               <div className="w-10 h-10 bg-bg border-2 border-border rounded-sm flex items-center justify-center shadow-brutal-sm transition-colors text-text">
                 {method.icon}

--- a/src/components/EmergencyToggle.tsx
+++ b/src/components/EmergencyToggle.tsx
@@ -21,9 +21,11 @@ export default function EmergencyToggle({ isEmergency, onToggle }: EmergencyTogg
           </div>
         </div>
         <button
+          role="switch"
+          aria-checked={isEmergency}
           aria-label={isEmergency ? "Turn off emergency mode" : "Turn on emergency mode"}
           onClick={onToggle}
-          className={`relative w-14 h-7 rounded-full border-2 border-border transition-colors ${isEmergency ? 'bg-red-500' : 'bg-bg'}`}
+          className={`relative w-14 h-7 rounded-full border-2 border-border transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-2 ${isEmergency ? 'bg-red-500' : 'bg-bg'}`}
         >
           <motion.div
             animate={{ x: isEmergency ? 26 : 2 }}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -30,6 +30,8 @@ export default function Settings() {
               </div>
             </div>
             <button
+              role="switch"
+              aria-checked={darkMode}
               aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
               onClick={() => setDarkMode(!darkMode)}
               className={`relative w-14 h-8 rounded-sm border-2 border-border transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-2 ${darkMode ? 'bg-primary' : 'bg-surface'}`}

--- a/test_accessibility.py
+++ b/test_accessibility.py
@@ -1,0 +1,49 @@
+from playwright.sync_api import sync_playwright
+
+def run_cuj(page):
+    page.goto("http://localhost:3000/")
+
+    # Mock state
+    page.evaluate("""
+        () => {
+            localStorage.setItem('fd_user', JSON.stringify({id: 'user-1', name: 'Test User', phone: '1234567890'}));
+            localStorage.setItem('fd_onboarding_complete', 'true');
+        }
+    """)
+    page.reload()
+    page.wait_for_timeout(1000)
+
+    # Go to settings page
+    page.goto("http://localhost:3000/settings")
+    page.wait_for_timeout(2000)
+
+    # Focus dark mode switch
+    page.locator('button[role="switch"]').focus()
+    page.wait_for_timeout(500)
+
+    page.screenshot(path="/home/jules/verification/screenshots/settings_focus.png")
+
+    # Toggle dark mode
+    page.keyboard.press("Space")
+    page.wait_for_timeout(500)
+
+    page.screenshot(path="/home/jules/verification/screenshots/settings_dark_mode.png")
+    page.wait_for_timeout(1000)
+
+
+if __name__ == "__main__":
+    import os
+    os.makedirs("/home/jules/verification/screenshots", exist_ok=True)
+    os.makedirs("/home/jules/verification/videos", exist_ok=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/home/jules/verification/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
**What:**
- Replaced `className="hidden"` with `className="sr-only"` for native radio inputs in the Checkout Payment Methods component, and used Tailwind's `:has()` modifier (`has-[:focus-visible]:ring-2`) on the parent labels.
- Added `role="switch"`, `aria-checked`, and explicit `focus-visible` styles to the Emergency mode toggle.
- Added `role="switch"` and `aria-checked` to the Dark mode toggle in Settings.

**Why:**
Custom UI controls built with standard elements need specific configuration to remain accessible. Hiding native radio inputs using `hidden` (or `display: none`) removes them from the tab order completely. Using `sr-only` keeps them in the DOM and accessible via keyboard. Similarly, custom toggle switches built with `<button>` elements require the `role="switch"` and `aria-checked` attributes to properly communicate their state to screen readers.

**Before:**
- Payment method radio options could not be navigated to using the Tab key.
- Emergency and Dark mode toggles were announced as standard buttons and their active states were not communicated clearly to assistive technologies. 
- Emergency toggle lacked any focus ring.

**After:**
- Payment methods can be navigated and selected entirely with the keyboard.
- Switches are properly announced as toggle switches and convey their checked status.
- Consistent focus states across these interactive components.

**Accessibility:**
- Ensures screen reader users can interact with payment and settings controls effectively.
- Ensures keyboard-only users can navigate and activate custom inputs.
- Logged learning regarding the `sr-only` and `has-[:focus-visible]` pattern to `.jules/palette.md`.

---
*PR created automatically by Jules for task [16947369824007062841](https://jules.google.com/task/16947369824007062841) started by @dhaatrik*